### PR TITLE
Return canned reply in chat API

### DIFF
--- a/api/ChatController.php
+++ b/api/ChatController.php
@@ -17,7 +17,7 @@ class ChatController{
         $res=$db->query('SELECT body FROM canned_responses ORDER BY id LIMIT 1');
         if($row=$res->fetch()) $reply=$row['body'];
         $stmt->execute([$cid,'assistant',$reply,strlen($reply)]);
-        json_response(['ok'=>true,'data'=>['conversation_id'=>$cid]]);
+        json_response(['ok'=>true,'data'=>['conversation_id'=>$cid,'reply'=>$reply]]);
     }
     function conversation(){
         $id=$_GET['id']??0; $db=ai_db();

--- a/public/chat.js
+++ b/public/chat.js
@@ -26,11 +26,22 @@ async function loadConversation(id){
 document.getElementById('send-btn').addEventListener('click',sendMessage);
 
 async function sendMessage(){
-  const content=document.getElementById('chat-input').value;
+  const content=document.getElementById('chat-input').value.trim();
   if(!content) return;
   const r=await api('chat/send','POST',{conversation_id:window.currentConversation,content});
   document.getElementById('chat-input').value='';
   if(r.ok){
-    loadConversation(r.data.conversation_id);
+    window.currentConversation=r.data.conversation_id;
+    const msgs=document.getElementById('messages');
+    const userDiv=document.createElement('div');
+    userDiv.className='msg user';
+    userDiv.textContent='user: '+content;
+    msgs.appendChild(userDiv);
+    const assistantDiv=document.createElement('div');
+    assistantDiv.className='msg assistant';
+    assistantDiv.textContent='assistant: '+r.data.reply;
+    msgs.appendChild(assistantDiv);
+  } else {
+    alert(r.error||'Failed to send message');
   }
 }


### PR DESCRIPTION
## Summary
- Include assistant reply in `chat/send` API response
- Display user and assistant messages immediately in chat UI and handle errors

## Testing
- `php -l api/ChatController.php`
- `node --check public/chat.js`


------
https://chatgpt.com/codex/tasks/task_e_68959aa9d40c83309a7856885095f5ca